### PR TITLE
Change OpenAPI format for TZNaive

### DIFF
--- a/src/phantom/datetime.py
+++ b/src/phantom/datetime.py
@@ -41,4 +41,5 @@ class TZNaive(datetime.datetime, Phantom, predicate=is_tz_naive):
         return {
             **super().__schema__(),  # type: ignore[misc]
             "description": "A date-time without timezone data.",
+            "format": "date-time-naive",
         }

--- a/src/phantom/schema.py
+++ b/src/phantom/schema.py
@@ -10,6 +10,7 @@ class Schema(TypedDict, total=False):
     title: str
     description: str
     type: Literal["array", "string", "float", "number"]
+    format: str
     examples: Sequence[object]
     minimum: Optional[float]
     maximum: Optional[float]

--- a/src/phantom/schema.py
+++ b/src/phantom/schema.py
@@ -18,7 +18,6 @@ class Schema(TypedDict, total=False):
     exclusiveMaximum: Optional[float]
     minItems: Optional[int]
     maxItems: Optional[int]
-    format: str
 
 
 class SchemaField:

--- a/tests/pydantic/test_pydantic_schemas.py
+++ b/tests/pydantic/test_pydantic_schemas.py
@@ -135,7 +135,7 @@ class TestShippedTypesImplementsSchema:
             "title": "TZNaive",
             "description": "A date-time without timezone data.",
             "type": "string",
-            "format": "date-time",
+            "format": "date-time-naive",
         }
 
     def test_re_match_implements_schema(self):


### PR DESCRIPTION
Naive datetimes are not compatible with the OpenAPI "date-time" format which mandates timezone data.

https://datatracker.ietf.org/doc/html/rfc3339#section-5.6