### PR TITLE
Fix Mypy errors in strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ from phantom import Phantom
 from phantom.predicates.collection import contained
 
 
-class Name(str, Phantom, predicate=contained({"Jane", "Joe"})):
+class Name(str, Phantom[object], predicate=contained({"Jane", "Joe"})):
     ...
 
 
-def greet(name: Name):
+def greet(name: Name) -> None:
     print(f"Hello {name}!")
 ```
 


### PR DESCRIPTION
Python program in README.md:

```python
from phantom import Phantom
from phantom.predicates.collection import contained


class Name(str, Phantom, predicate=contained({"Jane", "Joe"})):
    ...


def greet(name: Name):
    print(f"Hello {name}!")


greet(Name.parse("Jane"))

joe = "Joe"
assert isinstance(joe, Name)
greet(joe)

greet("bird")
```

Mypy output:

```
$ mypy foobar.py --strict                
foobar.py:5: error: Missing type parameters for generic type "Phantom"
foobar.py:9: error: Function is missing a return type annotation
foobar.py:18: error: Argument 1 to "greet" has incompatible type "str"; expected "Name"
Found 3 errors in 1 file (checked 1 source file)
```