### PR TITLE
Workaround for generic subclass failure on 3.11

### DIFF
--- a/src/phantom/negated.py
+++ b/src/phantom/negated.py
@@ -21,6 +21,8 @@ T = TypeVar("T")
 
 class SequenceNotStr(
     Sequence[T],
+    # Explicitly pass object here as workaround for this issue:
+    # https://github.com/python/cpython/issues/94607
     Phantom[object],
     Generic[T],
     # Note: We don't eliminate mutable types here like in PhantomSized. This is because

--- a/src/phantom/negated.py
+++ b/src/phantom/negated.py
@@ -21,7 +21,7 @@ T = TypeVar("T")
 
 class SequenceNotStr(
     Sequence[T],
-    Phantom,
+    Phantom[object],
     Generic[T],
     # Note: We don't eliminate mutable types here like in PhantomSized. This is because
     # the property of not being a str cannot change by mutation, so this specific


### PR DESCRIPTION
See https://github.com/python/cpython/issues/94607#issuecomment-1176271096