### PR TITLE
Make datetime.tzinfo non-optional for TZAware

### DIFF
--- a/src/phantom/datetime.py
+++ b/src/phantom/datetime.py
@@ -20,6 +20,10 @@ class TZAware(datetime.datetime, Phantom, predicate=is_tz_aware):
     True
     """
 
+    # A property of being aware is (dt.tzinfo != None), so we can safely narrow this
+    # attribute to not include None.
+    tzinfo: datetime.tzinfo
+
     @classmethod
     def __schema__(cls) -> Schema:
         return {

--- a/tests/test_datetime.yaml
+++ b/tests/test_datetime.yaml
@@ -28,3 +28,14 @@
     reveal_type(dt.tzinfo) # N: Revealed type is "Union[datetime.tzinfo, None]"
     assert isinstance(dt, TZAware)
     reveal_type(dt.tzinfo) # N: Revealed type is "datetime.tzinfo"
+- case: bound_is_not_erased
+  main: |
+    import datetime
+    from phantom.datetime import TZAware, TZNaive
+
+    o: datetime.datetime
+    aware = TZAware.parse(o)
+    naive = TZNaive.parse(o)
+
+    reveal_type(aware.month) # N: Revealed type is "builtins.int"
+    reveal_type(naive.month) # N: Revealed type is "builtins.int"

--- a/tests/test_datetime.yaml
+++ b/tests/test_datetime.yaml
@@ -19,3 +19,12 @@
       TZAware.parse(datetime.datetime.now(tz=datetime.timezone.utc))
     )
     reveal_type(b) # N: Revealed type is "phantom.datetime.TZAware"
+- case: narrowing_to_tz_aware_makes_tzinfo_non_optional
+  main: |
+    import datetime
+    from phantom.datetime import TZAware
+
+    dt: datetime.datetime
+    reveal_type(dt.tzinfo) # N: Revealed type is "Union[datetime.tzinfo, None]"
+    assert isinstance(dt, TZAware)
+    reveal_type(dt.tzinfo) # N: Revealed type is "datetime.tzinfo"


### PR DESCRIPTION
This PR makes it so that accessing `.tzinfo` on a `datetime.datetime` object that has been narrowed to `TZAware` has the type `datetime.tzinfo` instead of `datetime.tzinfo | None`. This is safe because this check is already part of the predicate, ie by definition of `isinstance(_, TZAware)`.

It also addresses #84 for `TZAware` and `TZNaive`, by checking that accessing an attribute from `datetime.datetime` does not raise a static type checking error.