### PR TITLE
feat: class docstring overrides default description from __schema__

### DIFF
--- a/src/phantom/schema.py
+++ b/src/phantom/schema.py
@@ -25,24 +25,42 @@ class Schema(TypedDict, total=False):
     maxLength: Optional[int]
 
 
-def desc_from_docstring(cls) -> str:
-    # ds = (next(filter(lambda x: x.__doc__, cls.__mro__), cls).__doc__ or "").strip()
-    ds = (cls.__doc__ or "").strip()
+def _take_first(predicate, sequence, default=None):
+    # NOTE: should I move this somewhere else?
+    return next(filter(predicate, sequence), default)
 
-    if not ds:
+
+def _description_from_docstring(cls) -> str:
+    """Extract and reformat docstring from passed class or closest parent.
+
+    Returns description text with fixed indentation, or
+    an empty string in case the docstring is not present.
+    """
+    closest_docstring_parent = _take_first(lambda x: x.__doc__, cls.__mro__, cls)
+    docstring = (closest_docstring_parent.__doc__ or "")
+    if not docstring:
         return ""
-    lines = ds.split("\n", maxsplit=1)
+
+    lines = docstring.strip().split("\n", maxsplit=1)
     if len(lines) == 1:
-        return ds
-    rest = textwrap.dedent(lines[1])
-    if fst := lines[0].strip():
-        return f"{fst}\n{rest}"
-    else:
-        return rest
+        return docstring
+
+    return "\n".join((lines[0].strip(), textwrap.dedent(lines[1])))
+
+def _fixup_description(cls, field_schema):
+    docstring_cls = cls
+    if cls.__use_docstring__:
+        # use_docstring=True for given class
+        field_schema["description"] = _description_from_docstring(docstring_cls)
+    elif "description" not in field_schema:
+        # use_docstring might have been set in a parent
+        # -> must use it, if no description was provided in __schema__
+        docstring_cls = _take_first(lambda x: x.__use_docstring__, cls.__mro__)
+        if docstring_cls:
+            field_schema["description"] = _description_from_docstring(docstring_cls)
 
 
 class SchemaField:
-    __use_docstring__: ClassVar[str]
 
     @classmethod
     @final
@@ -56,9 +74,8 @@ class SchemaField:
         field_schema.update(
             {key: value for key, value in cls.__schema__().items() if value is not None}
         )
-        if cls.__use_docstring__:
-            if ds := desc_from_docstring(cls):
-                field_schema["description"] = ds
+        _fixup_description(cls, field_schema)
+
 
     @classmethod
     def __schema__(cls) -> Schema:


### PR DESCRIPTION
fixes #238

I do it in `__modify_schema__`, so that the docstring, if present, is applied **last** and not first (which would be the case when just adding it in `__schema__`)