### PR TITLE
Add `TypeGuard` to `is_formatted_phone_number`

### DIFF
--- a/src/phantom/ext/phonenumbers.py
+++ b/src/phantom/ext/phonenumbers.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 from typing import Final
 from typing import cast
-from typing_extensions import TypeGuard
 
 import phonenumbers
+from typing_extensions import TypeGuard
 
 from phantom import Phantom
 from phantom.bounds import parse_str

--- a/src/phantom/ext/phonenumbers.py
+++ b/src/phantom/ext/phonenumbers.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from typing import Final
 from typing import cast
+from typing_extensions import TypeGuard
 
 import phonenumbers
 
@@ -67,7 +68,7 @@ def normalize_phone_number(
 is_phone_number = excepts(InvalidPhoneNumber)(_deconstruct_phone_number)
 
 
-def is_formatted_phone_number(number: str) -> bool:
+def is_formatted_phone_number(number: str) -> TypeGuard[FormattedPhoneNumber]:
     try:
         return number == normalize_phone_number(number)
     except InvalidPhoneNumber:

--- a/tests/ext/test_phonenumbers.py
+++ b/tests/ext/test_phonenumbers.py
@@ -1,4 +1,5 @@
 import pytest
+from typing_extensions import assert_type
 
 from phantom.errors import BoundError
 from phantom.ext.phonenumbers import FormattedPhoneNumber
@@ -103,8 +104,10 @@ class TestIsPhoneNumber:
 
 
 class TestIsFormattedPhoneNumber:
-    def test_returns_true_for_formatted_number(self):
-        assert is_formatted_phone_number("+46123456789") is True
+    def test_returns_true_for_formatted_number(self) -> None:
+        value = "+46123456789"
+        assert is_formatted_phone_number(value)
+        assert_type(value, FormattedPhoneNumber)
 
     def test_returns_false_for_unformatted_number(self):
         assert is_formatted_phone_number("+46 (123) 456 789") is False


### PR DESCRIPTION
I added an `assert_type` row since it seems that you are checking types with `pytest-mypy-plugins` but I figured using `assert_type` is probably preferable