### PR TITLE
fix: Pin typeguard<4.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,10 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    typeguard>=4
+    # typeguard 4.3.0 breaks "intersection" protocols, see linked issue. I didn't figure
+    # out a way to work around this at the moment, so it needs to be pinned.
+    # https://github.com/antonagestam/phantom-types/issues/299
+    typeguard>=4,<4.3.0
     typing_extensions>=4.3.0
     numerary>=0.4.3
 


### PR DESCRIPTION
typeguard 4.3.0 introduced refined support for protocol type checking, unfortunately this breaks some existing usages in phantom-types, which in turn breaks sized types. As there's seemingly no trivial way to work around the issue, this commit pins typeguard at 4.3.0 until there is a fix upstream.

https://github.com/antonagestam/phantom-types/issues/299